### PR TITLE
Show index of circular references and trim of code to 80 columns

### DIFF
--- a/test.js
+++ b/test.js
@@ -79,7 +79,7 @@ assert.equal(
     toSource(object),
     "{ a:1,\n"+
     "  b:2,\n"+
-    "  c:{$circularReference:1} }"
+    "  c:{$circularReference:0} }"
 )
 
 // Not a circular reference

--- a/tosource.js
+++ b/tosource.js
@@ -1,7 +1,8 @@
 /* toSource by Marcello Bastea-Forte - zlib license */
 module.exports = function(object, filter, indent, startingIndent) {
     var seen = []
-    return walk(object, filter, indent === undefined ? '  ' : (indent || ''), startingIndent || '', seen)
+    return walk(object, filter, indent === undefined ? '  ' : (indent || ''),
+                startingIndent || '', seen)
 
     function walk(object, filter, indent, currentIndent, seen) {
         var nextIndent = currentIndent + indent
@@ -20,11 +21,13 @@ module.exports = function(object, filter, indent, startingIndent) {
         if (object instanceof RegExp) return object.toString()
         if (object instanceof Date) return 'new Date('+object.getTime()+')'
 
-        if (seen.indexOf(object) >= 0) return '{$circularReference:1}'
+        var index = seen.indexOf(object);
+        if (index >= 0) return '{$circularReference:'+index+'}'
         seen.push(object)
 
         function join(elements) {
-            return indent.slice(1) + elements.join(','+(indent&&'\n')+nextIndent) + (indent ? ' ' : '');
+          return indent.slice(1) + elements.join(','+(indent&&'\n')+nextIndent)
+                 + (indent ? ' ' : '');
         }
 
         if (Array.isArray(object)) {
@@ -34,7 +37,8 @@ module.exports = function(object, filter, indent, startingIndent) {
         }
         var keys = Object.keys(object)
         return keys.length ? '{' + join(keys.map(function (key) {
-            return (legalKey(key) ? key : JSON.stringify(key)) + ':' + walk(object[key], filter, indent, nextIndent, seen.slice())
+          return (legalKey(key) ? key : JSON.stringify(key)) + ':'
+                  + walk(object[key], filter, indent, nextIndent, seen.slice());
         })) + '}' : '{}'
     }
 }


### PR DESCRIPTION
The index could allow to identify what's the instance that is doing the circular reference (maybe in the future could be added support to set a reference to it when decoding the object, maybe exporting someway the list of seen objects).

The limit to 80 columns makes it easier to read the code, I didn't do it on the regular expresion but it would be also possible setting it by a string and a RegEx object constructor.
